### PR TITLE
Fix Vaadin-Widgetset location in MANIFEST.MF

### DIFF
--- a/WebContent/META-INF/MANIFEST.MF
+++ b/WebContent/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Implementation-Vendor: Sami Ekblad
 Implementation-Title: Overlays
 Implementation-Version: 1.0.0
 Vaadin-Package-Version: 1
-Vaadin-Widgetsets: org.vaadin.overlay.OverlaysWidgetset
+Vaadin-Widgetsets: org.vaadin.overlay.widgetset.OverlaysWidgetset
 


### PR DESCRIPTION
The location of the widgetset is wrong. Without this fix, the widgetset cannot be compiled.